### PR TITLE
Add project instructions for Codex agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# McpLite Agent Instructions
+
+McpLite is a Ruby gem with a Rust extension. It provides a simple way to build MCP servers that run over stdio. All Ruby sources are under `lib/`, while the Rust extension lives in `ext/mcp_lite`.
+
+## Running checks
+
+Always run `bundle exec rake` before committing. This command compiles the extension, runs Ruby and Rust tests, and lints the code with StandardRB and clippy.
+
+## Development tips
+
+- Use Ruby 3.1 or newer.
+- Install dependencies with `bin/setup` or `bundle install`.
+- Avoid committing build artifacts such as `target/` from Cargo.
+


### PR DESCRIPTION
## Summary
- add root `AGENTS.md` describing project overview and how to run checks

## Testing
- `bundle exec rake` *(fails: `cargo-clippy` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685695d277b4833299ca8717989283f4