### PR TITLE
Add cargo fmt instruction and format code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ MicroMcp is a Ruby gem with a Rust extension. It provides a simple way to build 
 
 ## Running checks
 
-Always run `bundle exec rake` before committing. This command compiles the extension, runs Ruby and Rust tests, and lints the code with StandardRB and clippy.
+Always run `bundle exec rake` before committing. This command compiles the extension, runs Ruby and Rust tests, and lints the code with StandardRB and clippy. Additionally, run `cargo fmt --all` to keep the Rust code formatted consistently.
 
 ## Development tips
 

--- a/ext/micro_mcp/src/lib.rs
+++ b/ext/micro_mcp/src/lib.rs
@@ -1,5 +1,5 @@
-mod utils;
 mod server;
+mod utils;
 
 use magnus::{function, prelude::*, Error, Ruby};
 

--- a/ext/micro_mcp/src/utils.rs
+++ b/ext/micro_mcp/src/utils.rs
@@ -1,5 +1,5 @@
-use std::{ffi::c_void, mem::MaybeUninit, ptr::null_mut};
 use rb_sys::{rb_thread_call_with_gvl, rb_thread_call_without_gvl};
+use std::{ffi::c_void, mem::MaybeUninit, ptr::null_mut};
 
 unsafe extern "C" fn call_without_gvl<F, R>(arg: *mut c_void) -> *mut c_void
 where


### PR DESCRIPTION
## Summary
- recommend running `cargo fmt --all` before committing
- format Rust sources with cargo fmt

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_6857230fc5f88332b5422b862a998e29