### PR TITLE
Improve server error handling

### DIFF
--- a/ext/micro_mcp/src/server.rs
+++ b/ext/micro_mcp/src/server.rs
@@ -40,7 +40,7 @@ fn tools() -> &'static Mutex<HashMap<String, ToolEntry>> {
 }
 
 pub fn register_tool(
-    _ruby: &Ruby,
+    ruby: &Ruby,
     name: String,
     description: Option<String>,
     handler: Proc,


### PR DESCRIPTION
## Summary
- avoid panicking unwraps in server implementation
- adjust unit test to propagate errors

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_68571b6a096c8332a217fab24ec05c6d