### PR TITLE
Add runtime sampling interface

### DIFF
--- a/ext/micro_mcp/src/lib.rs
+++ b/ext/micro_mcp/src/lib.rs
@@ -8,5 +8,6 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     let module = ruby.define_module("MicroMcpNative")?;
     module.define_singleton_method("start_server", function!(server::start_server, 0))?;
     module.define_singleton_method("register_tool", function!(server::register_tool, 3))?;
+    server::init_ruby(ruby, module)?;
     Ok(())
 }

--- a/ext/micro_mcp/src/server.rs
+++ b/ext/micro_mcp/src/server.rs
@@ -165,7 +165,7 @@ impl ServerHandler for MyServerHandler {
                 let text_result: Result<String, Error> = crate::utils::with_gvl(|| {
                     let ruby = Ruby::get().unwrap();
                     let runtime_val = ruby.obj_wrap(RuntimeHandle::new(runtime));
-                    proc.call::<_, String>((ruby.qnil(), runtime_val))
+                    proc.call::<_, String>((runtime_val,))
                 });
                 match text_result {
                     Ok(text) => Ok(CallToolResult::text_content(text, None)),

--- a/lib/micro_mcp.rb
+++ b/lib/micro_mcp.rb
@@ -4,6 +4,7 @@ require_relative "micro_mcp/version"
 require_relative "micro_mcp/micro_mcp"
 require_relative "micro_mcp/tool_registry"
 require_relative "micro_mcp/server"
+require_relative "micro_mcp/runtime"
 
 module MicroMcp
   class Error < StandardError; end

--- a/lib/micro_mcp/runtime.rb
+++ b/lib/micro_mcp/runtime.rb
@@ -2,14 +2,20 @@
 
 require "json"
 
-module MicroMcp
-  class Runtime < MicroMcpNative::Runtime
+module MicroMcpNative
+  class Runtime
+    alias_method :__native_sample!, :sample!
+
     def sample!(params)
       raise "Client does not support sampling" unless sampling_supported?
 
       json = params.to_json
-      result = super(json)
+      result = __native_sample!(json)
       JSON.parse(result)
     end
   end
+end
+
+module MicroMcp
+  Runtime = MicroMcpNative::Runtime
 end

--- a/lib/micro_mcp/runtime.rb
+++ b/lib/micro_mcp/runtime.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "json"
+
+module MicroMcp
+  class Runtime < MicroMcpNative::Runtime
+    def sample!(params)
+      raise "Client does not support sampling" unless sampling_supported?
+
+      json = params.to_json
+      result = super(json)
+      JSON.parse(result)
+    end
+  end
+end

--- a/test/runtime_test.rb
+++ b/test/runtime_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class RuntimeTest < Minitest::Test
+  def test_sample_delegates_to_native
+    runtime = MicroMcp::Runtime.allocate
+    called = false
+    runtime.define_singleton_method(:__native_sample!) do |json|
+      called = true
+      json
+    end
+    runtime.define_singleton_method(:sampling_supported?) { true }
+
+    result = runtime.sample!(foo: "bar")
+
+    assert_equal({"foo" => "bar"}, result)
+    assert called
+  end
+end

--- a/test/support/say_hello_random_language_tool.rb
+++ b/test/support/say_hello_random_language_tool.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+MicroMcp::ToolRegistry.register_tool(
+  name: "say_hello_random_language",
+  description: "Say hello in a random language using sampling"
+) do |runtime|
+  runtime.sample!(
+    messages: [
+      {role: "user", content: "Say hello in a random language"}
+    ]
+  )
+end

--- a/test/support/say_hello_random_language_tool.rb
+++ b/test/support/say_hello_random_language_tool.rb
@@ -4,9 +4,14 @@ MicroMcp::ToolRegistry.register_tool(
   name: "say_hello_random_language",
   description: "Say hello in a random language using sampling"
 ) do |runtime|
-  runtime.sample!(
+  result = runtime.sample!(
     messages: [
-      {role: "user", content: "Say hello in a random language"}
-    ]
+      {
+        role: "user",
+        content: {type: "text", text: "Say hello in a random language"}
+      }
+    ],
+    maxTokens: 5
   )
+  result["content"]["text"]
 end


### PR DESCRIPTION
## Summary
- expose new `Runtime` class to provide sampling from Ruby
- pass runtime to tool blocks so they can call `sample!`
- add sample tool test

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_6857d46b48488332857aac0da1bdc062