### PR TITLE
Expose runtime in Ruby tools

### DIFF
--- a/ext/micro_mcp/src/lib.rs
+++ b/ext/micro_mcp/src/lib.rs
@@ -1,12 +1,19 @@
 mod server;
 mod utils;
 
-use magnus::{function, prelude::*, Error, Ruby};
+use magnus::{function, method, prelude::*, Error, Ruby};
 
 #[magnus::init]
 fn init(ruby: &Ruby) -> Result<(), Error> {
-    let module = ruby.define_module("MicroMcpNative")?;
-    module.define_singleton_method("start_server", function!(server::start_server, 0))?;
-    module.define_singleton_method("register_tool", function!(server::register_tool, 3))?;
+    let native = ruby.define_module("MicroMcpNative")?;
+    native.define_singleton_method("start_server", function!(server::start_server, 0))?;
+    native.define_singleton_method("register_tool", function!(server::register_tool, 3))?;
+
+    let parent = ruby.define_module("MicroMcp")?;
+    let class = parent.define_class("Runtime", ruby.class_object())?;
+    class.define_method(
+        "is_initialized",
+        method!(server::RubyMcpServer::is_initialized, 0),
+    )?;
     Ok(())
 }

--- a/test/support/runtime_lifetime_tool.rb
+++ b/test/support/runtime_lifetime_tool.rb
@@ -1,0 +1,20 @@
+module RuntimeStore
+  class << self
+    attr_accessor :captured_runtime
+  end
+end
+
+MicroMcp::ToolRegistry.register_tool(
+  name: "capture_runtime",
+  description: "captures runtime"
+) do |runtime|
+  RuntimeStore.captured_runtime = runtime
+  runtime.is_initialized.to_s
+end
+
+MicroMcp::ToolRegistry.register_tool(
+  name: "use_captured_runtime",
+  description: "uses captured runtime"
+) do |_|
+  RuntimeStore.captured_runtime.is_initialized.to_s
+end


### PR DESCRIPTION
## Summary
- expose `McpServer` runtime to Ruby tool handlers
- define `MicroMcp::Runtime` Ruby class wrapping a scoped server reference
- ensure reference cannot be used after tool call
- test lifetime enforcement with a Ruby integration test

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_6857fb7094c88332811accbd714f874a