### PR TITLE
Expose client_supports_sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Ruby `ToolRegistry` for registering tools dynamically
 - Access to the MCP runtime from Ruby tools
 - Argument support for tools
+- Exposed `client_supports_sampling` on runtime
 
 ### Changed
 - Gem renamed from `mcp_lite` to `micro_mcp`

--- a/ext/micro_mcp/src/lib.rs
+++ b/ext/micro_mcp/src/lib.rs
@@ -15,5 +15,9 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
         "is_initialized",
         method!(server::RubyMcpServer::is_initialized, 0),
     )?;
+    class.define_method(
+        "client_supports_sampling",
+        method!(server::RubyMcpServer::client_supports_sampling, 0),
+    )?;
     Ok(())
 }

--- a/test/support/client_capabilities_tool.rb
+++ b/test/support/client_capabilities_tool.rb
@@ -1,0 +1,6 @@
+MicroMcp::ToolRegistry.register_tool(
+  name: "client_sampling_supported",
+  description: "reports if client supports sampling"
+) do |_args, runtime|
+  runtime.client_supports_sampling.inspect
+end


### PR DESCRIPTION
## Summary
- expose `client_supports_sampling` on the runtime
- add Ruby helper for checking client sampling capability
- test runtime method from Rust
- document the new method in CHANGELOG

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_685851225b64833285b8b759edba037f