### PR TITLE
Expose create_message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Access to the MCP runtime from Ruby tools
 - Argument support for tools
 - Exposed `client_supports_sampling` on runtime
+- Exposed `create_message` on runtime
 
 ### Changed
 - Gem renamed from `mcp_lite` to `micro_mcp`

--- a/ext/micro_mcp/src/lib.rs
+++ b/ext/micro_mcp/src/lib.rs
@@ -20,5 +20,9 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
         "client_supports_sampling",
         method!(server::RubyMcpServer::client_supports_sampling, 0),
     )?;
+    class.define_method(
+        "create_message",
+        method!(server::RubyMcpServer::create_message, 1),
+    )?;
     Ok(())
 }

--- a/test/support/create_message_tool.rb
+++ b/test/support/create_message_tool.rb
@@ -1,0 +1,20 @@
+MicroMcp::ToolRegistry.register_tool(
+  name: "create_message_text",
+  description: "invokes runtime.create_message"
+) do |_args, runtime|
+  result = runtime.create_message(
+    {
+      "messages" => [
+        {"role" => "user", "content" => {"type" => "text", "text" => "What is the capital of France?"}}
+      ],
+      "modelPreferences" => {
+        "hints" => [{"name" => "claude-3-sonnet"}],
+        "intelligencePriority" => 0.8,
+        "speedPriority" => 0.5
+      },
+      "systemPrompt" => "You are a helpful assistant.",
+      "maxTokens" => 100
+    }
+  )
+  result["content"]["text"]
+end

--- a/test/test_micro_mcp.rb
+++ b/test/test_micro_mcp.rb
@@ -7,6 +7,10 @@ class TestMicroMcp < Minitest::Test
     refute_nil ::MicroMcp::VERSION
   end
 
+  def test_runtime_exposes_create_message
+    assert_includes MicroMcp::Runtime.instance_methods(false), :create_message
+  end
+
   def test_it_does_something_useful
     assert true
   end


### PR DESCRIPTION
## Summary
- expose `create_message` on runtime so Ruby tools can invoke sampling
- add Ruby test to ensure `create_message` method is present
- add example tool for calling `create_message`

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_68587efcff188332979dd68c26d151de