### PR TITLE
Update rust-mcp-sdk to v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Gem renamed from `mcp_lite` to `micro_mcp`
 - Tool handling uses a dynamic registry
 - Improved server error handling
+- Updated dependency `rust-mcp-sdk` to 0.5.0
 
 ## [0.1.0] - 2025-06-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-macros"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375eba9388d9d5ffc8951e5f25296f9739be4e5700375ac7c74ad957a903b92b"
+checksum = "5a495ee12964fa392044792db4e9da78c94756e186a5712e5d7e625c143419ff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1105,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-schema"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a794de25669a2d21c5074ec5082f74f5e88863a112339fe90264d9e480b0ee8b"
+checksum = "fec1ff3507a619b9945f60a94dac448541aef8c9803aa6192c30f4a932cb1499"
 dependencies = [
  "serde",
  "serde_json",
@@ -1115,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.4.7"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f03dc968444ec56bdcddf17536b4b6860136a0d81d987f2fb909d5aec61ed7"
+checksum = "1fb7d9a1fdcf02efee5cd21a568f31c819b7f2d767c42b37cb79aab302ac5b35"
 dependencies = [
  "async-trait",
  "futures",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-transport"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5a7f8e688f8b15d67f8d94cc0481cd08c9f4e848f4b9e832677dd5fdb063e"
+checksum = "d7f5468b8a00e800c3d708321216439ee1ad433592d725df93668bff75436348"
 dependencies = [
  "async-trait",
  "bytes",

--- a/ext/micro_mcp/Cargo.toml
+++ b/ext/micro_mcp/Cargo.toml
@@ -15,8 +15,8 @@ magnus = { version = "0.7", features = ["rb-sys"] }
 rb-sys = { version = "*", default-features = false, features = [
   "stable-api-compiled-fallback",
 ] }
-rust-mcp-sdk = { version = "0.4.3", default-features = false, features = [
-  "server", "client", "2025_03_26"
+rust-mcp-sdk = { version = "0.5.0", default-features = false, features = [
+  "server", "client", "2025_06_18"
 ]}
 serde = "1.0.219"
 serde_json = "1.0.140"

--- a/ext/micro_mcp/src/server.rs
+++ b/ext/micro_mcp/src/server.rs
@@ -4,7 +4,7 @@ use rust_mcp_sdk::{
     schema::{
         schema_utils::CallToolError, CallToolRequest, CallToolResult, Implementation,
         InitializeResult, ListToolsRequest, ListToolsResult, RpcError, ServerCapabilities,
-        ServerCapabilitiesTools, Tool, ToolInputSchema, LATEST_PROTOCOL_VERSION,
+        ServerCapabilitiesTools, TextContent, Tool, ToolInputSchema, LATEST_PROTOCOL_VERSION,
     },
     McpServer, StdioTransport, TransportOptions,
 };
@@ -184,7 +184,10 @@ pub fn register_tool(
         annotations: None,
         description,
         input_schema: schema,
+        meta: None,
         name: name.clone(),
+        output_schema: None,
+        title: None,
     };
 
     let handler_fn = RubyHandler(handler);
@@ -257,7 +260,9 @@ impl ServerHandler for MyServerHandler {
                 });
                 wrapper.invalidate();
                 match text_result {
-                    Ok(text) => Ok(CallToolResult::text_content(text, None)),
+                    Ok(text) => Ok(CallToolResult::text_content(vec![TextContent::new(
+                        text, None, None,
+                    )])),
                     Err(e) => Err(CallToolError::new(std::io::Error::other(e.to_string()))),
                 }
             }
@@ -277,6 +282,7 @@ pub fn start_server() -> String {
             let server_details = InitializeResult {
                 server_info: Implementation {
                     name: "Hello World MCP Server".to_string(),
+                    title: None,
                     version: "0.1.0".to_string(),
                 },
                 capabilities: ServerCapabilities {
@@ -363,7 +369,7 @@ mod tests {
             _runtime: &dyn McpClient,
         ) -> std::result::Result<CreateMessageResult, RpcError> {
             Ok(CreateMessageResult {
-                content: TextContent::new("hello".to_string(), None).into(),
+                content: TextContent::new("hello".to_string(), None, None).into(),
                 meta: None,
                 model: "test-model".to_string(),
                 role: Role::Assistant,
@@ -392,6 +398,7 @@ mod tests {
             capabilities: ClientCapabilities::default(),
             client_info: Implementation {
                 name: "test-client".into(),
+                title: None,
                 version: "0.1.0".into(),
             },
             protocol_version: LATEST_PROTOCOL_VERSION.into(),
@@ -434,6 +441,7 @@ mod tests {
             capabilities: ClientCapabilities::default(),
             client_info: Implementation {
                 name: "test-client".into(),
+                title: None,
                 version: "0.1.0".into(),
             },
             protocol_version: LATEST_PROTOCOL_VERSION.into(),
@@ -490,6 +498,7 @@ mod tests {
             capabilities: ClientCapabilities::default(),
             client_info: Implementation {
                 name: "test-client".into(),
+                title: None,
                 version: "0.1.0".into(),
             },
             protocol_version: LATEST_PROTOCOL_VERSION.into(),
@@ -544,6 +553,7 @@ mod tests {
             capabilities: ClientCapabilities::default(),
             client_info: Implementation {
                 name: "test-client".into(),
+                title: None,
                 version: "0.1.0".into(),
             },
             protocol_version: LATEST_PROTOCOL_VERSION.into(),
@@ -583,6 +593,7 @@ mod tests {
             capabilities: ClientCapabilities::default(),
             client_info: Implementation {
                 name: "test-client".into(),
+                title: None,
                 version: "0.1.0".into(),
             },
             protocol_version: LATEST_PROTOCOL_VERSION.into(),

--- a/lib/micro_mcp.rb
+++ b/lib/micro_mcp.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "micro_mcp/version"
-ruby_version = "#{RUBY_VERSION[/\d+\.\d+/]}"
+ruby_version = RUBY_VERSION[/\d+\.\d+/].to_s
 begin
   require_relative "micro_mcp/micro_mcp"
 rescue LoadError

--- a/scripts/build_platforms.rb
+++ b/scripts/build_platforms.rb
@@ -19,7 +19,7 @@ end
 
 def main
   puts "Building MicroMcp gem for multiple platforms..."
-  puts "Platforms: #{PLATFORMS.join(', ')}"
+  puts "Platforms: #{PLATFORMS.join(", ")}"
   puts "Ruby versions: #{RUBY_VERSIONS}"
   puts
 


### PR DESCRIPTION
## Summary
- upgrade `rust-mcp-sdk` to 0.5.0
- adjust server to new schema fields
- adapt tests and helper code for updated API
- fix StandardRB lints
- document the dependency update in the changelog

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_686cddb2e0c08332b1d1c694fe3151ba