### PR TITLE
Add prompt registry support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Argument support for tools
 - Exposed `client_supports_sampling` on runtime
 - Exposed `create_message` on runtime
+- Prompt registry for registering prompts with arguments and runtime access
 
 ### Changed
 - Gem renamed from `mcp_lite` to `micro_mcp`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Tool handling uses a dynamic registry
 - Improved server error handling
 - Updated dependency `rust-mcp-sdk` to 0.5.0
+- Rooted stored Ruby `Proc` objects to avoid GC issues
 
 ## [0.1.0] - 2025-06-17
 

--- a/ext/micro_mcp/src/lib.rs
+++ b/ext/micro_mcp/src/lib.rs
@@ -9,6 +9,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     native.define_singleton_method("start_server", function!(server::start_server, 0))?;
     native.define_singleton_method("shutdown_server", function!(server::shutdown_server, 0))?;
     native.define_singleton_method("register_tool", function!(server::register_tool, 4))?;
+    native.define_singleton_method("register_prompt", function!(server::register_prompt, 4))?;
 
     let parent = ruby.define_module("MicroMcp")?;
     let class = parent.define_class("Runtime", ruby.class_object())?;

--- a/ext/micro_mcp/src/server.rs
+++ b/ext/micro_mcp/src/server.rs
@@ -16,7 +16,11 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use tokio::runtime::Runtime;
 
-use magnus::{block::Proc, value::ReprValue, Error, Ruby, Value};
+use magnus::{
+    block::Proc,
+    value::{BoxValue, ReprValue},
+    Error, Ruby, Value,
+};
 use magnus::{typed_data::DataTypeFunctions, TypedData};
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -32,8 +36,13 @@ fn shutdown_flag() -> &'static Arc<AtomicBool> {
 
 type ToolHandler = RubyHandler;
 
-#[derive(Clone)]
-struct RubyHandler(Proc);
+struct RubyHandler(BoxValue<Proc>);
+
+impl Clone for RubyHandler {
+    fn clone(&self) -> Self {
+        RubyHandler(BoxValue::new(*self.0.as_ref()))
+    }
+}
 
 // SAFETY: We only call the stored Proc while holding the GVL.
 unsafe impl Send for RubyHandler {}
@@ -234,7 +243,7 @@ pub fn register_tool(
         title: None,
     };
 
-    let handler_fn = RubyHandler(handler);
+    let handler_fn = RubyHandler(BoxValue::new(handler));
 
     let mut map = tools()
         .lock()
@@ -274,7 +283,7 @@ pub fn register_prompt(
 
     let entry = PromptEntry {
         prompt,
-        handler: RubyHandler(handler),
+        handler: RubyHandler(BoxValue::new(handler)),
     };
 
     let mut map = prompts()
@@ -316,7 +325,7 @@ impl ServerHandler for MyServerHandler {
         })?;
         match map.get(&request.params.name) {
             Some(entry) => {
-                let proc = entry.handler.0;
+                let proc = *entry.handler.0.as_ref();
                 let wrapper = RubyMcpServer::new(runtime);
                 let args_value = if let Some(map) = &request.params.arguments {
                     let json = JsonValue::Object(
@@ -392,7 +401,7 @@ impl ServerHandler for MyServerHandler {
             .map_err(|_| CallToolError::new(std::io::Error::other("tools mutex poisoned")))?;
         match map.get(request.tool_name()) {
             Some(entry) => {
-                let proc = entry.handler.0;
+                let proc = *entry.handler.0.as_ref();
                 let wrapper = RubyMcpServer::new(runtime);
                 let args_value = if let Some(map) = &request.params.arguments {
                     let json = JsonValue::Object(map.clone());

--- a/lib/micro_mcp.rb
+++ b/lib/micro_mcp.rb
@@ -13,6 +13,7 @@ rescue LoadError
 end
 require_relative "micro_mcp/schema"
 require_relative "micro_mcp/tool_registry"
+require_relative "micro_mcp/prompt_registry"
 require_relative "micro_mcp/server"
 require_relative "micro_mcp/runtime_helpers"
 require_relative "micro_mcp/validation_helpers"

--- a/lib/micro_mcp/prompt_registry.rb
+++ b/lib/micro_mcp/prompt_registry.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module MicroMcp
+  module PromptRegistry
+    def self.register_prompt(name:, description: nil, arguments: nil, &block)
+      raise ArgumentError, "block required" unless block
+
+      MicroMcpNative.register_prompt(name, description, arguments, block)
+    end
+  end
+end

--- a/test/support/prompt_example.rb
+++ b/test/support/prompt_example.rb
@@ -9,7 +9,9 @@ PR.register_prompt(
     {name: "name", description: "Name to greet"}
   ]
 ) do |args, runtime|
-  runtime.is_initialized
+  unless runtime.is_initialized
+    raise "Runtime is not initialized"
+  end
   name = args["name"] || "world"
   [
     {"role" => "user", "content" => {"type" => "text", "text" => "Hello #{name}"}},

--- a/test/support/prompt_example.rb
+++ b/test/support/prompt_example.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+PR = MicroMcp::PromptRegistry
+
+PR.register_prompt(
+  name: "greeting",
+  description: "Simple greeting prompt",
+  arguments: [
+    {name: "name", description: "Name to greet"}
+  ]
+) do |args, runtime|
+  runtime.is_initialized
+  name = args["name"] || "world"
+  [
+    {"role" => "user", "content" => {"type" => "text", "text" => "Hello #{name}"}},
+    {"role" => "assistant", "content" => {"type" => "text", "text" => "Hi!"}}
+  ]
+end


### PR DESCRIPTION
## Summary
- implement server-side prompt handling with runtime access
- allow prompts to accept arguments via register_prompt
- update prompt test to use arguments

## Testing
- `cargo fmt --all`
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_686d8880efd08332870a9c4273a8e521