### PR TITLE
Document GC rules and root Ruby procs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Tool handling uses a dynamic registry
 - Improved server error handling
 - Updated dependency `rust-mcp-sdk` to 0.5.0
+- Rooted stored Ruby `Proc` objects to avoid GC issues
 
 ## [0.1.0] - 2025-06-17
 


### PR DESCRIPTION
## Summary
- root stored `Proc` objects in global registry with `BoxValue`
- document Ruby/Rust GC guidelines in `ext/micro_mcp/AGENTS.md`
- note the fix in the changelog

## Testing
- `cargo fmt --all`
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_686f59bc39e4833282857808c4129602