### PR TITLE
Merge main and fix GC-safe prompt handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Tool handling uses a dynamic registry
 - Improved server error handling
 - Updated dependency `rust-mcp-sdk` to 0.5.0
+- Rooted stored Ruby `Proc` objects to avoid GC issues
 
 ## [0.1.0] - 2025-06-17
 

--- a/ext/micro_mcp/src/server.rs
+++ b/ext/micro_mcp/src/server.rs
@@ -16,7 +16,11 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use tokio::runtime::Runtime;
 
-use magnus::{block::Proc, value::ReprValue, Error, Ruby, Value};
+use magnus::{
+    block::Proc,
+    value::{BoxValue, ReprValue},
+    Error, Ruby, Value,
+};
 use magnus::{typed_data::DataTypeFunctions, TypedData};
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -32,8 +36,13 @@ fn shutdown_flag() -> &'static Arc<AtomicBool> {
 
 type ToolHandler = RubyHandler;
 
-#[derive(Clone)]
-struct RubyHandler(Proc);
+struct RubyHandler(BoxValue<Proc>);
+
+impl Clone for RubyHandler {
+    fn clone(&self) -> Self {
+        RubyHandler(BoxValue::new(*self.0.as_ref()))
+    }
+}
 
 // SAFETY: We only call the stored Proc while holding the GVL.
 unsafe impl Send for RubyHandler {}
@@ -234,7 +243,7 @@ pub fn register_tool(
         title: None,
     };
 
-    let handler_fn = RubyHandler(handler);
+    let handler_fn = RubyHandler(BoxValue::new(handler));
 
     let mut map = tools()
         .lock()
@@ -274,7 +283,7 @@ pub fn register_prompt(
 
     let entry = PromptEntry {
         prompt,
-        handler: RubyHandler(handler),
+        handler: RubyHandler(BoxValue::new(handler)),
     };
 
     let mut map = prompts()
@@ -316,7 +325,7 @@ impl ServerHandler for MyServerHandler {
         })?;
         match map.get(&request.params.name) {
             Some(entry) => {
-                let proc = entry.handler.0;
+                let proc = *entry.handler.0.as_ref();
                 let wrapper = RubyMcpServer::new(runtime);
                 let args_value = if let Some(map) = &request.params.arguments {
                     let json = JsonValue::Object(
@@ -392,7 +401,7 @@ impl ServerHandler for MyServerHandler {
             .map_err(|_| CallToolError::new(std::io::Error::other("tools mutex poisoned")))?;
         match map.get(request.tool_name()) {
             Some(entry) => {
-                let proc = entry.handler.0;
+                let proc = *entry.handler.0.as_ref();
                 let wrapper = RubyMcpServer::new(runtime);
                 let args_value = if let Some(map) = &request.params.arguments {
                     let json = JsonValue::Object(map.clone());


### PR DESCRIPTION
## Summary
- merge main branch for updated GC rules
- fix prompt handler to use `BoxValue` so Ruby procs stay rooted

## Testing
- `cargo fmt --all`
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_6870ab08727483328e859c15798dab4b